### PR TITLE
Remove outmoded shell scripts

### DIFF
--- a/scripts/blackbg.sh
+++ b/scripts/blackbg.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# The following "test" is directly from https://bugzilla.mozilla.org/show_bug.cgi?id=1511350#c0:
-
-adb shell am start -n org.mozilla.firefox/.App -a android.intent.action.VIEW -d "'data:text/html;base64,PGJvZHkgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6YmxhY2siPg=='" --ez showstartpane false

--- a/scripts/redbg.sh
+++ b/scripts/redbg.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# The following "test" is directly from https://bugzilla.mozilla.org/show_bug.cgi?id=1511350:
-
-adb shell am start -n org.mozilla.firefox/.App -a android.intent.action.VIEW -d "'data:text/html;base64,PGJvZHkgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6cmVkIj4='"

--- a/scripts/whitebg.sh
+++ b/scripts/whitebg.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# The following "test" is directly from https://bugzilla.mozilla.org/show_bug.cgi?id=1511350#c0:
-
-adb shell am start -n org.mozilla.firefox/.App -a android.intent.action.VIEW -d "'data:text/html;base64,PGJvZHkgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6d2hpdGUiPg=='" --ez showstartpane false


### PR DESCRIPTION
Supplanted with https://github.com/mozilla/powerusage-android/blob/ce122aa90c669b54e2445adfc164ad937be36a0d/scripts/blackbg-test.sh